### PR TITLE
set "Access-Control-Allow-Origin: *" on raw block/tx requests

### DIFF
--- a/htdocs/includes/app_explore.inc
+++ b/htdocs/includes/app_explore.inc
@@ -651,6 +651,7 @@ function page_rawtx($vars, $params) {
 
     Cache::handle_client_side_etag();
     header("Content-type: text/plain");
+    header("Access-Control-Allow-Origin: *");
     echo $raw;
 }
 
@@ -667,6 +668,7 @@ function page_rawblock($vars, $params) {
 
     Cache::handle_client_side_etag();
     header("Content-type: text/plain");
+    header("Access-Control-Allow-Origin: *");
     echo $raw;
 }
 


### PR DESCRIPTION
Due to same-origin policy, JavaScript apps can't properly process the response of XMLHttpRequest if it doesn't have the Access-Control-Allow-Origin header.
